### PR TITLE
feat: Enable caching of uploaded files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "entity-tag"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217415a79b7e4f29b2f0db27fc98b916b2f89d7937035948439db90dbefd2b79"
+dependencies = [
+ "base64 0.21.7",
+ "highway",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1669,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "highway"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040319a6910b901d5d49cbada4a99db52836a1b63228a05f7e2b7f8feef89b1"
 
 [[package]]
 name = "hkdf"
@@ -2508,6 +2524,7 @@ dependencies = [
  "chrono",
  "common",
  "entity",
+ "entity-tag",
  "migration",
  "openidconnect",
  "rocket",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "meta-tv-rs"
 chrono = "0.4.40"
 common = { path = "../common", features = ["entity"] }
 entity = { path = "../entity" }
+entity-tag = "0.1.8"
 migration = { path = "../migration" }
 openidconnect = { version = "4.0.0", features = ["timing-resistant-secret-traits"] }
 rocket = { version = "0.5.1", features = ["json", "secrets"] }

--- a/crates/backend/src/cached_file.rs
+++ b/crates/backend/src/cached_file.rs
@@ -1,0 +1,73 @@
+use std::{fs::Metadata, io, path::Path};
+
+use chrono::{DateTime, Utc};
+use entity_tag::EntityTag;
+use rocket::{fs, http::Status, response, Request, Response};
+
+/// Wrapper around [`rocket::fs::NamedFile`] which sets appropriate headers to allow better caching.
+///
+/// It adds the following response headers:
+/// - `etag`
+/// - `last-modified`
+/// - `cache-control` with a configured max age
+///
+/// It also responds to the `if-none-match` request header.
+pub struct CachedFile<'etag> {
+    file: fs::NamedFile,
+    metadata: Metadata,
+    etag: EntityTag<'etag>,
+    max_age: chrono::Duration,
+}
+
+impl<'etag> CachedFile<'etag> {
+    pub async fn open(
+        path: impl AsRef<Path>,
+        etag: EntityTag<'etag>,
+        max_age: chrono::Duration,
+    ) -> io::Result<Self> {
+        let file = fs::NamedFile::open(path).await?;
+        let metadata = file.metadata().await?;
+
+        Ok(Self {
+            file,
+            metadata,
+            etag,
+            max_age,
+        })
+    }
+}
+
+impl<'etag, 'r> response::Responder<'r, 'r> for CachedFile<'etag> {
+    fn respond_to(self, req: &Request) -> response::Result<'r> {
+        if let Some(etag) = req
+            .headers()
+            .get("if-none-match")
+            .next()
+            .and_then(|raw_etag| EntityTag::from_str(raw_etag).ok())
+        {
+            if etag == self.etag {
+                return Response::build().status(Status::NotModified).ok();
+            }
+        }
+
+        let modification_time: DateTime<Utc> = self
+            .metadata
+            .modified()
+            .expect("modification time is available on the relevant platforms")
+            .into();
+
+        Response::build_from(self.file.respond_to(req)?)
+            .raw_header(
+                "last-modified",
+                modification_time
+                    .format("%a, %d %b %Y %H:%M:%S GMT")
+                    .to_string(),
+            )
+            .raw_header("etag", format!("{}", self.etag))
+            .raw_header(
+                "cache-control",
+                format!("max-age={}", self.max_age.num_seconds()),
+            )
+            .ok()
+    }
+}

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -16,6 +16,7 @@ use sea_orm_rocket::Database;
 extern crate rocket;
 
 mod auth;
+mod cached_file;
 mod error;
 mod files;
 mod guards;


### PR DESCRIPTION
Makes the `/uploads/*` routes respond with appropriate headers to allow clients to cache the requests:

- `last-modified`
- `etag`
- `cache-control`

while additionally supporting the `if-none-match` request header.

I'm not sure if the `last-modified` and `cache-control` headers are strictly necessary to allow the client browser to cache the requests, but adding them doesn't hurt and I don't have time to figure it out. :)

This required adding `entity_tag` as a new dependency to the backend crate.

Resolves #23