### PR TITLE
fix: Relax slide iframe sandbox restrictions

### DIFF
--- a/crates/frontend/src/components/content.rs
+++ b/crates/frontend/src/components/content.rs
@@ -58,7 +58,7 @@ pub fn ContentItem(
                             ContentType::Html => {
                                 view! {
                                     <iframe
-                                        sandbox=""
+                                        sandbox="allow-scripts allow-same-origin"
                                         class="object-contain h-full w-full"
                                         src=format!("/uploads/{}", content.file_path)
                                         on:click=move |_| is_upload_dialog_open.set(true)

--- a/crates/frontend/src/components/feed.rs
+++ b/crates/frontend/src/components/feed.rs
@@ -73,7 +73,7 @@ pub fn ScreenFeedSlideshow(feed: Signal<Vec<FeedEntryDto>>) -> impl IntoView {
                         ContentType::Html => {
                             view! {
                                 <iframe
-                                    sandbox="allow-scripts"
+                                    sandbox="allow-scripts allow-same-origin"
                                     class="object-contain h-screen w-screen"
                                     src=format!("/uploads/{}", entry.file_path)
                                 />


### PR DESCRIPTION
Adds the "allow-same-origin" flag to the iframe sandbox attribute. This seems to fix loading of HTML slide graphics. Without it I get the CORS error "Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at ..." for every resource the embedded html document tries to load.

Also makes the slide graphics previews have the same sandbox permissions as the slide view displayed on the TVs.

I honestly don't understand why the flag fixes the issue. This probably opens up some security vulnerability, but I've spent 2+ hours reading up on CORS and I'm still non the wiser, so I don't care anymore. :)

Fixes #21 