### PR TITLE
feat: Add options to Create Slide Group page

### DIFF
--- a/crates/backend/src/routes/slide_group.rs
+++ b/crates/backend/src/routes/slide_group.rs
@@ -178,12 +178,17 @@ pub async fn create_slide_group(
     slide_group: Json<CreateSlideGroupDto>,
 ) -> Result<CreatedResponse, AppError> {
     let db = conn.into_inner();
+    
+    let owner = match &slide_group.owner {
+        None => OwnerDto::User(session.username),
+        Some(group) => OwnerDto::Group(group.clone()),
+    };
 
     let group = entity::slide_group::ActiveModel {
         title: Set(slide_group.title.clone()),
         priority: Set(slide_group.priority),
         hidden: Set(slide_group.hidden),
-        created_by: Set(session.username),
+        created_by: Set(owner.id()),
         start_date: Set(slide_group.start_date.naive_utc()),
         end_date: Set(slide_group.end_date.as_ref().map(|d| d.naive_utc())),
         archive_date: Set(None),
@@ -445,6 +450,7 @@ mod tests {
             .put("/api/slide-group/1")
             .json(&CreateSlideGroupDto {
                 title: "Lorem Ipsum".to_string(),
+                owner: None,
                 priority: 1,
                 hidden: false,
                 start_date: DateTimeUtc::from_timestamp_nanos(1739471974000000),
@@ -482,6 +488,7 @@ mod tests {
             .put("/api/slide-group/1")
             .json(&CreateSlideGroupDto {
                 title: "Lorem Ipsum".to_string(),
+                owner: None,
                 priority: 1,
                 hidden: false,
                 start_date: DateTimeUtc::from_timestamp_nanos(1739471974000000),
@@ -506,6 +513,7 @@ mod tests {
             .put("/api/slide-group/1")
             .json(&CreateSlideGroupDto {
                 title: "Lorem Ipsum".to_string(),
+                owner: None,
                 priority: 1,
                 hidden: false,
                 start_date: DateTimeUtc::from_timestamp_nanos(1739471974000000),

--- a/crates/backend/src/test_utils.rs
+++ b/crates/backend/src/test_utils.rs
@@ -85,6 +85,7 @@ pub fn util_create_slide_group(client: &TestClient) {
         .post("/api/slide-group")
         .json(&CreateSlideGroupDto {
             title: "Lorem Ipsum".to_string(),
+            owner: None,
             priority: 0,
             hidden: false,
             start_date: DateTimeUtc::from_timestamp_nanos(1739471974000000),

--- a/crates/common/src/dtos.rs
+++ b/crates/common/src/dtos.rs
@@ -123,6 +123,8 @@ impl From<TaggedGroupDto> for GroupDto {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CreateSlideGroupDto {
     pub title: String,
+    // The owner of the new slide group. None signifies the currently logged in user.
+    pub owner: Option<GroupDto>,
     pub priority: i32,
     pub hidden: bool,
     pub start_date: DateTime<Utc>,

--- a/crates/frontend/public/styles.css
+++ b/crates/frontend/public/styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @plugin "./daisyui.js" {
   themes: light --default, dark --prefersdark;
-  include: button, card, skeleton, select, alert, tooltip;
+  include: button, card, skeleton, select, alert, tooltip, input;
   logs: false;
 }
 
@@ -31,13 +31,18 @@
   }
 }
 
+@layer utilities {
+  .input {
+    @apply flex
+  }
+  .select {
+    @apply flex
+  }
+}
+
 @layer components {
   .label {
     @apply block mb-2 text-sm font-medium text-gray-900 dark:text-white;
-  }
-
-  .input {
-    @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
   }
 }
 

--- a/crates/frontend/src/components/mod.rs
+++ b/crates/frontend/src/components/mod.rs
@@ -7,5 +7,6 @@ pub mod layout;
 pub mod slide;
 pub mod slide_group;
 pub mod slide_group_options;
+pub mod start_end_date_fieldset;
 pub mod topbar;
 pub mod utils;

--- a/crates/frontend/src/components/slide_group_options.rs
+++ b/crates/frontend/src/components/slide_group_options.rs
@@ -100,6 +100,7 @@ fn SlideGroupEditOptions(
             submit_action
                 .dispatch(CreateSlideGroupDto {
                     title: title.read().to_string(),
+                    owner: None,
                     priority: *priority.read(),
                     hidden: *hidden.read(),
                     start_date: *start_date.read(),
@@ -189,7 +190,7 @@ fn SlideGroupEditOptions(
                                             <input
                                                 class="col-start-1 row-start-1 input"
                                                 type="datetime-local"
-                                                step=1
+                                                step=60
                                                 prop:value=move || { datetime_to_input(&start_date.get()) }
                                                 on:change:target=move |ev| {
                                                     if let Some(dt) = input_to_datetime(&ev.target().value()) {
@@ -215,7 +216,7 @@ fn SlideGroupEditOptions(
                                                         <input
                                                             class="col-start-1 row-start-1 input"
                                                             type="datetime-local"
-                                                            step=1
+                                                            step=60
                                                             prop:value=move || { datetime_to_input(&end_date_value) }
                                                             on:change:target=move |ev| {
                                                                 if let Some(dt) = input_to_datetime(&ev.target().value()) {

--- a/crates/frontend/src/components/slide_group_options.rs
+++ b/crates/frontend/src/components/slide_group_options.rs
@@ -118,7 +118,7 @@ fn SlideGroupEditOptions(
                           <div class="mt-2">
                             <input
                                 name="title"
-                                class="input block w-full rounded-md px-3 py-1.5 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                                class="input"
                                 type="text"
                                 bind:value=title
                             />
@@ -187,7 +187,7 @@ fn SlideGroupEditOptions(
                                     <div class="flex w-full items-center">
                                         <div class="grid w-full grid-cols-1">
                                             <input
-                                                class="col-start-1 row-start-1 input border disabled:bg-gray-50 disabled:text-gray-500"
+                                                class="col-start-1 row-start-1 input"
                                                 type="datetime-local"
                                                 step=1
                                                 prop:value=move || { datetime_to_input(&start_date.get()) }
@@ -213,7 +213,7 @@ fn SlideGroupEditOptions(
                                                 <div class="flex w-full items-center">
                                                     <div class="grid w-full grid-cols-1">
                                                         <input
-                                                            class="col-start-1 row-start-1 input border disabled:bg-gray-50 disabled:text-gray-500"
+                                                            class="col-start-1 row-start-1 input"
                                                             type="datetime-local"
                                                             step=1
                                                             prop:value=move || { datetime_to_input(&end_date_value) }

--- a/crates/frontend/src/components/slide_group_options.rs
+++ b/crates/frontend/src/components/slide_group_options.rs
@@ -6,11 +6,14 @@ use leptos_icons::Icon;
 
 use crate::{
     api::{self, AppError},
-    components::{alert::Alert, dialog::Dialog, error::ErrorList, slide::SlideList},
+    components::{
+        alert::Alert, dialog::Dialog, error::ErrorList, slide::SlideList,
+        start_end_date_fieldset::StartEndDateFieldset,
+    },
     context::SlideGroupOptionsContext,
     utils::{
         bool::fmt_if,
-        datetime::{datetime_to_input, fmt_datetime, fmt_datetime_opt, input_to_datetime},
+        datetime::{fmt_datetime, fmt_datetime_opt},
     },
 };
 
@@ -53,8 +56,14 @@ fn SlideGroupEditOptions(
     let priority = RwSignal::new(slide_group.get_untracked().priority);
     let hidden = RwSignal::new(slide_group.get_untracked().hidden);
     let start_date = RwSignal::new(slide_group.get_untracked().start_date);
-    let end_date = RwSignal::new(slide_group.get_untracked().end_date);
-
+    let end_date = RwSignal::new(
+        slide_group
+            .get_untracked()
+            .end_date
+            .map(|date| (true, date))
+            .unwrap_or_else(|| (false, Utc::now())),
+    );
+    
     let submit_action = Action::new_local(move |data: &CreateSlideGroupDto| {
         let id = slide_group.get().id;
         let data = data.clone();
@@ -104,10 +113,13 @@ fn SlideGroupEditOptions(
                     priority: *priority.read(),
                     hidden: *hidden.read(),
                     start_date: *start_date.read(),
-                    end_date: *end_date.read(),
+                    end_date: match end_date.get() {
+                        (true, date) => Some(date),
+                        (false, _) => None,
+                    },
                 });
         }>
-            <div class="space-y-12">
+            <div class="space-y-12 max-w-max m-auto">
                 <div class="border-b border-gray-100/10 pb-12">
                     <fieldset disabled=is_submitting>
                         <h2 class="text-base/7 font-semibold">General</h2>
@@ -179,88 +191,22 @@ fn SlideGroupEditOptions(
                     </fieldset>
                 </div>
                 <div class="border-b border-gray-900/10 pb-12">
-                    <fieldset disabled=is_submitting>
-                        <h2 class="text-base/7 font-semibold">Active Timespan</h2>
-                        <div class="col-span-full mt-6">     
-                            <label for="start-date" class="block text-sm/6 font-medium">Start</label>
-                            <div class="mt-3 space-y-6">
-                                <div class="flex gap-3">
-                                    <div class="flex w-full items-center">
-                                        <div class="grid w-full grid-cols-1">
-                                            <input
-                                                class="col-start-1 row-start-1 input"
-                                                type="datetime-local"
-                                                step=60
-                                                prop:value=move || { datetime_to_input(&start_date.get()) }
-                                                on:change:target=move |ev| {
-                                                    if let Some(dt) = input_to_datetime(&ev.target().value()) {
-                                                        start_date.set(dt);
-                                                    }
-                                                }
-                                            />
-                                            <p class="mt-3 text-sm/6 text-gray-600">Dates are in Swedish time</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        {move || match end_date.get() {
-                            Some(end_date_value) => {
-                                view! {
-                                    <div class="col-span-full mt-6">     
-                                        <label for="end-date" class="block text-sm/6 font-medium">End</label>
-                                        <div class="mt-3 space-y-6">
-                                            <div class="flex gap-3">
-                                                <div class="flex w-full items-center">
-                                                    <div class="grid w-full grid-cols-1">
-                                                        <input
-                                                            class="col-start-1 row-start-1 input"
-                                                            type="datetime-local"
-                                                            step=60
-                                                            prop:value=move || { datetime_to_input(&end_date_value) }
-                                                            on:change:target=move |ev| {
-                                                                if let Some(dt) = input_to_datetime(&ev.target().value()) {
-                                                                    end_date.set(Some(dt));
-                                                                }
-                                                            }
-                                                        />
-                                                        <p class="mt-3 text-sm/6 text-gray-600">Dates are in Swedish time</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <button class="btn" type="button" on:click=move |_| { end_date.set(None) }>
-                                        Remove end date
-                                    </button>
-                                }
-                                    .into_any()
-                            }
-                            None => {
-
-                                view! {
-                                    <button
-                                        class="btn"
-                                        type="button"
-                                        on:click=move |_| { end_date.set(Some(Utc::now())) }
-                                    >
-                                        Add end date
-                                    </button>
-                                }
-                                    .into_any()
-                            }
-                        }}
-                        <div class="mt-6 flex gap-6">
-                            <button type="submit" class="btn border disabled:text-gray-500">
-                                Save
-                            </button>
-                            <button class="btn" type="button" on:click=move |_| set_editing_options.set(false)>
-                                Cancel
-                            </button>
-                            <button class="btn btn-soft btn-error" type="button" on:click=move |_| is_delete_dialog_open.set(true)>
-                                Delete Group
-                            </button>
-                        </div>
+                    <StartEndDateFieldset
+                        start_date=start_date
+                        end_date=end_date
+                        disable_end_date_removal_reason=None
+                        disabled=is_submitting
+                    />
+                    <fieldset class="mt-6 flex gap-6" disabled=is_submitting>
+                        <button type="submit" class="btn border disabled:text-gray-500">
+                            Save
+                        </button>
+                        <button class="btn" type="button" on:click=move |_| set_editing_options.set(false)>
+                            Cancel
+                        </button>
+                        <button class="btn btn-soft btn-error" type="button" on:click=move |_| is_delete_dialog_open.set(true)>
+                            Delete Group
+                        </button>
                     </fieldset>
                 </div>
             </div>

--- a/crates/frontend/src/components/start_end_date_fieldset.rs
+++ b/crates/frontend/src/components/start_end_date_fieldset.rs
@@ -10,6 +10,8 @@ pub fn StartEndDateFieldset(
     start_date: RwSignal<DateTime<Utc>>,
     end_date: RwSignal<(bool, DateTime<Utc>)>,
     disable_end_date_removal_reason: Option<&'static str>,
+    #[prop(into, default = false.into())]
+    disabled: Signal<bool>
 ) -> impl IntoView {
     let end_date_text = move || {
         if end_date.get().0 {
@@ -19,7 +21,7 @@ pub fn StartEndDateFieldset(
         }
     };
     view! {
-        <fieldset>
+        <fieldset disabled=disabled>
             <legend class="text-base/7 font-semibold">Active Timespan</legend>
             <div class="grid grid-cols-[repeat(auto-fit,_minmax(14rem,_1fr))] gap-x-8 gap-y-4 mt-4">
                 <div>

--- a/crates/frontend/src/components/start_end_date_fieldset.rs
+++ b/crates/frontend/src/components/start_end_date_fieldset.rs
@@ -1,0 +1,106 @@
+use crate::utils::datetime::{datetime_to_input, input_to_datetime};
+
+use chrono::{DateTime, Utc};
+use icondata as i;
+use leptos::prelude::*;
+use leptos_icons::Icon;
+
+#[component]
+pub fn StartEndDateFieldset(
+    start_date: RwSignal<DateTime<Utc>>,
+    end_date: RwSignal<(bool, DateTime<Utc>)>,
+    disable_end_date_removal_reason: Option<&'static str>,
+) -> impl IntoView {
+    let end_date_text = move || {
+        if end_date.get().0 {
+            "Remove end date"
+        } else {
+            "Add end date"
+        }
+    };
+    view! {
+        <fieldset>
+            <legend class="text-base/7 font-semibold">Active Timespan</legend>
+            <div class="grid grid-cols-[repeat(auto-fit,_minmax(14rem,_1fr))] gap-x-8 gap-y-4 mt-4">
+                <div>
+                    <label for="start-date" class="block text-sm/6 font-medium">
+                        Start
+                    </label>
+                    <div class="mt-3">
+                        <input
+                            class="col-start-1 row-start-1 input border disabled:bg-gray-50 disabled:text-gray-500"
+                            id="start-date"
+                            type="datetime-local"
+                            step=60
+                            prop:value=move || { datetime_to_input(&start_date.get()) }
+                            on:change:target=move |ev| {
+                                if let Some(dt) = input_to_datetime(&ev.target().value()) {
+                                    start_date.set(dt);
+                                }
+                            }
+                        />
+                    </div>
+                </div>
+                <div>
+                    {move || {
+                        match end_date.get() {
+                            (true, end_date_value) => {
+                                Some(
+                                    view! {
+                                        <div class="text-sm/6 font-medium flex flex-horizontal items-center gap-x-[0.3em]">
+                                            <label for="end-date">End</label>
+                                            <Show when=move || {
+                                                disable_end_date_removal_reason.is_some()
+                                            }>
+                                                <span
+                                                    class="tooltip"
+                                                    data-tip=disable_end_date_removal_reason.unwrap_or_default()
+                                                >
+                                                    <Icon
+                                                        icon=i::MdiInformationOutline
+                                                        width="1.1em"
+                                                        height="1.1em"
+                                                    />
+                                                </span>
+                                            </Show>
+                                        </div>
+                                        <div class="mt-3">
+                                            <input
+                                                class="col-start-1 row-start-1 input border disabled:bg-gray-50 disabled:text-gray-500"
+                                                id="end-date"
+                                                type="datetime-local"
+                                                step=60
+                                                prop:value=move || { datetime_to_input(&end_date_value) }
+                                                on:change:target=move |ev| {
+                                                    if let Some(date) = input_to_datetime(
+                                                        &ev.target().value(),
+                                                    ) {
+                                                        end_date.set((true, date));
+                                                    }
+                                                }
+                                            />
+                                        </div>
+                                    },
+                                )
+                            }
+                            _ => None,
+                        }
+                            .into_any()
+                    }}
+                </div>
+            </div>
+            <div class="flex justify-between items-top mt-3">
+                <p class="text-sm/6 text-gray-600">Dates are in Swedish time</p>
+                <Show when=move || disable_end_date_removal_reason.is_none()>
+                    <button
+                        class="btn"
+                        type="button"
+                        on:click=move |_| { end_date.update(|(enabled, _)| *enabled = !*enabled) }
+                    >
+                        {end_date_text}
+                    </button>
+                </Show>
+            </div>
+        </fieldset>
+    }
+}

--- a/crates/frontend/src/pages/create_slide_group.rs
+++ b/crates/frontend/src/pages/create_slide_group.rs
@@ -1,6 +1,11 @@
-use crate::{api, components::error::ErrorList};
-use common::dtos::CreateSlideGroupDto;
-use leptos::prelude::*;
+use crate::{
+    api::{self, AppError},
+    components::{error::ErrorList, start_end_date_fieldset::StartEndDateFieldset},
+};
+
+use chrono::Utc;
+use common::dtos::{CreateSlideGroupDto, GroupDto, UserInfoDto};
+use leptos::{html, logging, prelude::*};
 use leptos_router::components::Redirect;
 
 /// Page with form to create a new slide group
@@ -8,39 +13,81 @@ use leptos_router::components::Redirect;
 pub fn CreateSlideGroup() -> impl IntoView {
     let title = RwSignal::new("".to_string());
 
-    let submit_action = Action::new_local(|title: &String| {
+    let now = Utc::now();
+    let start_date = RwSignal::new(now.clone());
+    let end_date = RwSignal::new((
+        true,
+        now.with_timezone(&chrono_tz::Europe::Stockholm)
+            .checked_add_days(chrono::Days::new(
+                // If time is between 00:00 and 03:00, don't add day
+                if now.time() < chrono::NaiveTime::from_hms_opt(3, 0, 0).expect("03:00 is a time") {
+                    0
+                } else {
+                    1
+                },
+            ))
+            .unwrap_or_else(|| {
+                now.with_timezone(&chrono_tz::Europe::Stockholm) + chrono::Duration::hours(24)
+            })
+            .with_time(
+                chrono::NaiveTime::from_hms_opt(3, 0, 0)
+                    .expect("Rasmus thinks time exist (same as before)"),
+            ) // Make endtime 03:00 so things dissapear before people are back in META
+            .earliest()
+            .expect("Time is proably before Year 2038")
+            .with_timezone(&chrono::Utc),
+    ));
+
+    let user_info = use_context::<LocalResource<Result<UserInfoDto, AppError>>>()
+        .expect("User info has been provided");
+    let available_owners = Memo::new(move |_| {
+        [None]
+            .into_iter()
+            .chain(
+                user_info
+                    .get()
+                    .and_then(|info| info.map(|info| info.memberships).ok())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(GroupDto::from)
+                    .map(Some),
+            )
+            .collect::<Vec<_>>()
+    });
+    let username = move || {
+        user_info
+            .get()
+            .map(|result| {
+                result
+                    .map(|info| info.username)
+                    .inspect_err(|err| logging::error!("Failed fetching user info: {}", err))
+                    .unwrap_or_else(|_| "Logged in user".to_owned())
+            })
+            .unwrap_or_else(|| "Loading username...".to_owned())
+    };
+
+    let select = NodeRef::<html::Select>::new();
+    let selected_owner = move || {
+        let index = select
+            .get()
+            .expect("select element has been initialized")
+            .value()
+            .parse::<usize>()
+            .expect("Option's values are indices");
+
+        available_owners.get()[index].clone()
+    };
+
+    let submit_action = Action::new_local(move |title: &String| {
         let title = title.clone();
-        let now = chrono::Utc::now();
         async move {
             api::create_slide_group(&CreateSlideGroupDto {
                 title,
                 priority: 0,
                 hidden: false,
-                start_date: now.clone(),
-                end_date: Some(
-                    now.with_timezone(&chrono_tz::Europe::Stockholm)
-                        .checked_add_days(chrono::Days::new(
-                            // If time is between 00:00 and 03:00, don't add day
-                            if now.time()
-                                < chrono::NaiveTime::from_hms_opt(3, 0, 0).expect("03:00 is a time")
-                            {
-                                0
-                            } else {
-                                1
-                            },
-                        ))
-                        .unwrap_or_else(|| {
-                            now.with_timezone(&chrono_tz::Europe::Stockholm)
-                                + chrono::Duration::hours(24)
-                        })
-                        .with_time(
-                            chrono::NaiveTime::from_hms_opt(3, 0, 0)
-                                .expect("Rasmus thinks time exist (same as before)"),
-                        ) // Make endtime 03:00 so things dissapear before people are back in META
-                        .earliest()
-                        .expect("Time is proably before Year 2038")
-                        .with_timezone(&chrono::Utc),
-                ),
+                start_date: start_date.get(),
+                end_date: Some(end_date.get().1),
+                owner: selected_owner(),
             })
             .await
         }
@@ -57,25 +104,57 @@ pub fn CreateSlideGroup() -> impl IntoView {
 
     view! {
         <div class="container m-auto flex min-h-[80vh]">
-            <div class="card max-w-100 m-auto">
-                <form on:submit=move |ev| {
-                    ev.prevent_default();
-                    submit_action.dispatch(title.read().to_string());
-                }>
-                    <h1 class="text-4xl mb-4">"Create slide group"</h1>
+            <div class="card m-auto w-[35rem] max-w-full">
+                <form
+                    class="card-body"
+                    on:submit=move |ev| {
+                        ev.prevent_default();
+                        submit_action.dispatch(title.read().to_string());
+                    }
+                >
+                    <h1 class="card-title mb-2">"Create slide group"</h1>
                     <fieldset disabled=is_submitting>
                         <label class="label mb-4">
                             "Name"
                             <input
-                                class="input"
+                                class="input mt-3"
                                 type="text"
                                 placeholder="My amazing slideshow"
                                 bind:value=title
                             />
                         </label>
 
-                        <div class="flex justify-end">
-                            <button type="submit" class="btn">
+                        <label class="label mb-4">
+                            "Owner"
+                            <select class="select mt-3" node_ref=select>
+                                <ForEnumerate
+                                    each=move || available_owners.get()
+                                    key=|owner| owner.clone()
+                                    children=move |index, owner| {
+                                        let owner_copy = owner.clone();
+                                        view! {
+                                            <option selected=move || owner_copy.is_none() value=index>
+                                                {move || owner
+                                                    .clone()
+                                                    .map(|owner| owner.name)
+                                                    .unwrap_or_else(username)}
+                                            </option>
+                                        }
+                                    }
+                                />
+                            </select>
+                        </label>
+
+                        <StartEndDateFieldset
+                            start_date=start_date
+                            end_date=end_date
+                            disable_end_date_removal_reason=Some(
+                                "The end date can be removed after the slide group has been created.",
+                            )
+                        />
+
+                        <div class="card-actions justify-end">
+                            <button type="submit" class="btn btn-primary">
                                 Create
                             </button>
                         </div>

--- a/crates/frontend/src/utils/datetime.rs
+++ b/crates/frontend/src/utils/datetime.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use chrono_tz::{Europe, Tz};
 
-const DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+const DATE_FORMAT: &str = "%Y-%m-%dT%H:%M";
 
 const TIME_ZONE: Tz = Europe::Stockholm;
 


### PR DESCRIPTION
This adds options to the Create Slide Group page, allowing users to set the owner and start/end dates before the group has been created. The hope is that users will be more likely to enter correct values this way.

|Before|After|
|---|---|
|<img width="1437" height="930" alt="before_20260313_154039" src="https://github.com/user-attachments/assets/d8f2c0b3-498b-442f-bb52-eccf1adfdaf7" />|<img width="1437" height="930" alt="after_20260313_154052" src="https://github.com/user-attachments/assets/11b1ccd5-ba49-4a18-a54b-f3c4f32972f6" />|


While completing this I made two more changes (which correspond to the two extra commits):
- Removed all custom styling for `.input`s and, instead enabling the DaisyUI `input` component. Using DaisyUI components where possible leads to more consistent styling.
- Added the new start/end date widget to the Edit Slide Group view so that it's consistent with the create page.

Closes #49