### PR TITLE
Add Generative AI policy + link to Media's policy

### DIFF
--- a/crates/frontend/public/styles.css
+++ b/crates/frontend/public/styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @plugin "./daisyui.js" {
   themes: light --default, dark --prefersdark;
-  include: alert, button, card, checkbox, collapse, input, label, skeleton, select, tooltip;
+  include: alert, button, card, checkbox, collapse, input, label, link, skeleton, select, tooltip;
   logs: false;
 }
 

--- a/crates/frontend/src/components/content.rs
+++ b/crates/frontend/src/components/content.rs
@@ -47,7 +47,10 @@ pub fn ContentItem(
 
     view! {
         <div>
-            <p class="uppercase text-current/80 font-bold text-sm" id=content_description_id.clone()>
+            <p
+                class="uppercase text-current/80 font-bold text-sm"
+                id=content_description_id.clone()
+            >
                 {screen.name}
             </p>
             <div class="aspect-16/9 border">

--- a/crates/frontend/src/components/rules_body.rs
+++ b/crates/frontend/src/components/rules_body.rs
@@ -6,12 +6,21 @@ pub fn RulesBody() -> impl IntoView {
     view! {
         <ul
             role="list"
-            class="list-outside list-disc ps-[2ch] marker:content-['§_'] marker:font-bold marker:text-[1.2em] flex flex-col gap-1"
+            class="list-outside list-disc ps-[2ch] marker:content-['§_'] marker:font-bold marker:text-[1.2em] flex flex-col gap-1 max-w-[60ch]"
         >
             <li>
-                "Uploaded slide media must follow the chapters "
-                <a href="https://styrdokument.datasektionen.se/policies/uppforandepolicy">
-                    "Code of Conduct"
+                "Uploaded slide media must follow the "
+                <a
+                    class="link hover:text-current/80"
+                    href="https://styrdokument.datasektionen.se/policies/uppforandepolicy"
+                >
+                    "data chapter's Code of Conduct"
+                </a> " as well as the "
+                <a
+                    class="link hover:text-current/80"
+                    href="https://storage.googleapis.com/medieteknik-static/documents/2024/3/19/Uppförandepolicy%20EN.pdf"
+                >
+                    "media chapter's Code of Conduct"
                 </a> "."
             </li>
             <li>"Animated media must not contain blinking lights."</li>
@@ -20,6 +29,17 @@ pub fn RulesBody() -> impl IntoView {
                 <p class="ps-8 italic">
                     "This does not apply for slides only shown during an event."
                 </p>
+            </li>
+            <li>
+                "Per the "
+                <a
+                    class="link hover:text-current/80"
+                    href="https://styrdokument.datasektionen.se/pm/pm_informationsspridning#7-användning-av-generativ-ai"
+                >
+                    "data chapter's PM for Information Exchange"
+                </a>
+                " as well as the media chapter's Policy for Officials, slide media must not use "
+                "images or video created with generative AI."
             </li>
         </ul>
     }


### PR DESCRIPTION
Adds a link to Media's Code of Conduct, as well as the rule that images or video created with generative AI is forbidden. The rule is supposed to be added to Media's Policy for Officials, but it hasn't been updated yet, so I couldn't link to it.