### PR TITLE
Fix HTML content consuming pointer events

### DIFF
--- a/crates/frontend/src/components/content.rs
+++ b/crates/frontend/src/components/content.rs
@@ -38,7 +38,7 @@ pub fn ContentItem(
         ContentType::Html => view! {
             <iframe
                 sandbox="allow-scripts allow-same-origin"
-                class="object-contain h-full w-full"
+                class="object-contain h-full w-full pointer-events-none"
                 src=&content.url
             />
         }


### PR DESCRIPTION
Fixes the bug where it wasn't possible to replace HTML content, since the pointer events for the upload content button was consumed by the iframe with the HTML page placed inside it.

Closes #54 